### PR TITLE
[Fixed] Possible to use HTML comments for other scopes

### DIFF
--- a/comment-html-footer.sublime-snippet
+++ b/comment-html-footer.sublime-snippet
@@ -4,6 +4,5 @@
 
 ]]></content>
 	<tabTrigger>comm-html-footer</tabTrigger>
-	<scope>text.html</scope>
 	<description>Comment - HTML section footer</description>
 </snippet>

--- a/comment-html-header.sublime-snippet
+++ b/comment-html-header.sublime-snippet
@@ -6,6 +6,5 @@
 
 ]]></content>
 	<tabTrigger>comm-html-header</tabTrigger>
-	<scope>text.html</scope>
 	<description>Comment - HTML section header</description>
 </snippet>

--- a/comment-html-section.sublime-snippet
+++ b/comment-html-section.sublime-snippet
@@ -10,6 +10,5 @@ $2
 
 ]]></content>
 	<tabTrigger>comm-html-section</tabTrigger>
-	<scope>text.html</scope>
 	<description>Comment - HTML section</description>
 </snippet>

--- a/comment-html.sublime-snippet
+++ b/comment-html.sublime-snippet
@@ -4,6 +4,5 @@
 
 ]]></content>
 	<tabTrigger>comm-html</tabTrigger>
-	<scope>text.html</scope>
 	<description>Comment - HTML comment</description>
 </snippet>


### PR DESCRIPTION
I use your package for make `<!-- block comments -->` in XML. These comments format used also in the other syntaxes, [**NuGet**](https://packagecontrol.io/packages/NuGet), for example. I think, it would be nice don't use scope limit for HTML snippets.

Or you may add setting, for example,

```json
"html_snippet_syntax": ["XML/XML", "NuGet/NuGet"]
```

Users can add in setting their own syntax for personal use. But, I think, it's too much.

But edit snippets for personal use in package repository — is a bad idea, because if you want update your package, all users editing in package repository will be lost.

Thanks.